### PR TITLE
Improve Windows clipboard sync reliability

### DIFF
--- a/src/lib/client/Client.cpp
+++ b/src/lib/client/Client.cpp
@@ -46,6 +46,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <fstream>
+#include <algorithm>
+#include <functional>
 
 namespace inputleap {
 
@@ -87,6 +89,13 @@ Client::Client(IEventQueue* events, const std::string& name, const NetworkAddres
                               [this](const auto& e){ handle_file_chunk_sending(e); });
         m_events->add_handler(EventType::FILE_RECEIVE_COMPLETED, this,
                               [this](const auto& e){ handle_file_receive_completed(e); });
+    }
+
+    std::fill(std::begin(m_hashClipboard), std::end(m_hashClipboard), 0);
+
+    if (const char* env = std::getenv("INPUTLEAP_CLIPBOARD_MAX")) {
+        m_maximumClipboardSize = std::strtoul(env, nullptr, 10);
+        LOG_DEBUG("Using clipboard max size from env: %zu", m_maximumClipboardSize);
     }
 }
 
@@ -388,14 +397,19 @@ Client::sendClipboard(ClipboardID id)
     }
     m_screen->getClipboard(id, &clipboard);
 
-    // check time
-    if (m_timeClipboard[id] == 0 ||
-        clipboard.getTime() != m_timeClipboard[id]) {
-        // save new time
-        m_timeClipboard[id] = clipboard.getTime();
+    std::string data = clipboard.marshall();
+    std::size_t hash = std::hash<std::string>{}(data);
 
-        // marshall the data
-        std::string data = clipboard.marshall();
+    if (m_timeClipboard[id] == 0 ||
+        clipboard.getTime() != m_timeClipboard[id] ||
+        hash != m_hashClipboard[id]) {
+        if (clipboard.getTime() == m_timeClipboard[id] && hash != m_hashClipboard[id]) {
+            LOG_DEBUG("clipboard changed but timestamp unchanged; forcing update");
+        }
+
+        m_timeClipboard[id] = clipboard.getTime();
+        m_hashClipboard[id] = hash;
+
         if (data.size() >= m_maximumClipboardSize) {
             LOG_NOTE("Skipping clipboard transfer because the clipboard"
                 " contents exceeds the %zi MB size limit set by the server",
@@ -403,7 +417,6 @@ Client::sendClipboard(ClipboardID id)
             return;
         }
 
-        // save and send data if different or not yet sent
         if (!m_sentClipboard[id] || data != m_dataClipboard[id]) {
             m_sentClipboard[id] = true;
             m_dataClipboard[id] = data;
@@ -561,6 +574,7 @@ Client::handle_connected()
         m_ownClipboard[id]  = false;
         m_sentClipboard[id] = false;
         m_timeClipboard[id] = 0;
+        m_hashClipboard[id] = 0;
     }
 }
 
@@ -624,6 +638,7 @@ void Client::handle_clipboard_grabbed(const Event& event)
     m_ownClipboard[info.m_id]  = true;
     m_sentClipboard[info.m_id] = false;
     m_timeClipboard[info.m_id] = 0;
+    m_hashClipboard[info.m_id] = 0;
 
     // if we're not the active screen then send the clipboard now,
     // otherwise we'll wait until we leave.

--- a/src/lib/client/Client.h
+++ b/src/lib/client/Client.h
@@ -205,6 +205,7 @@ private:
     bool m_ownClipboard[kClipboardEnd];
     bool m_sentClipboard[kClipboardEnd];
     IClipboard::Time m_timeClipboard[kClipboardEnd];
+    std::size_t m_hashClipboard[kClipboardEnd];
     std::string m_dataClipboard[kClipboardEnd];
     IEventQueue* m_events;
     std::size_t m_expectedFileSize;

--- a/src/lib/platform/MSWindowsScreen.cpp
+++ b/src/lib/platform/MSWindowsScreen.cpp
@@ -104,6 +104,7 @@ MSWindowsScreen::MSWindowsScreen(
     m_mark(0),
     m_markReceived(0),
     m_fixTimer(nullptr),
+    m_clipboardTimer(nullptr),
     m_keyLayout(nullptr),
     m_screensaver(nullptr),
     m_screensaverNotify(false),
@@ -210,6 +211,10 @@ MSWindowsScreen::enable()
     m_events->add_handler(EventType::TIMER, m_fixTimer,
                           [this](const auto& e){ handle_fixes(); });
 
+    m_clipboardTimer = m_events->newTimer(1.0, nullptr);
+    m_events->add_handler(EventType::TIMER, m_clipboardTimer,
+                          [this](const auto& e){ checkClipboards(); });
+
     // install our clipboard snooper
     m_nextClipboardWindow = SetClipboardViewer(m_window);
 
@@ -262,6 +267,12 @@ MSWindowsScreen::disable()
         m_events->remove_handler(EventType::TIMER, m_fixTimer);
         m_events->deleteTimer(m_fixTimer);
         m_fixTimer = nullptr;
+    }
+
+    if (m_clipboardTimer != nullptr) {
+        m_events->remove_handler(EventType::TIMER, m_clipboardTimer);
+        m_events->deleteTimer(m_clipboardTimer);
+        m_clipboardTimer = nullptr;
     }
 
     m_isOnScreen = m_isPrimary;

--- a/src/lib/platform/MSWindowsScreen.h
+++ b/src/lib/platform/MSWindowsScreen.h
@@ -279,8 +279,9 @@ private:
     // the main loop's thread id
     DWORD m_threadID;
 
-    // timer for periodically checking stuff that requires polling
+    // timers for periodically checking stuff that requires polling
     EventQueueTimer* m_fixTimer;
+    EventQueueTimer* m_clipboardTimer;
 
     // the keyboard layout to use when off primary screen
     HKL m_keyLayout;


### PR DESCRIPTION
## Summary
- Detect clipboard changes via content hash to avoid missed syncs when timestamps stay the same
- Allow overriding maximum clipboard size via `INPUTLEAP_CLIPBOARD_MAX`
- Add periodic Windows clipboard polling to recover from lost WM_DRAWCLIPBOARD events

## Testing
- `./clean_build.sh` *(fails: CMake Error at CMakeLists.txt:78 (find_package): By not providing "FindQt6.cmake" in CMAKE_MODULE_PATH this project has asked CMake to find a package configuration file provided by "Qt6" ...)*

------
https://chatgpt.com/codex/tasks/task_e_689b207d47888330bfde8044c960dcd8